### PR TITLE
Upgrade to Scala 2.13.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 *.class
 *.log
 
+# SBT
+.bsp/
+
 target/
 
 # IntelliJ IDEA

--- a/build.sbt
+++ b/build.sbt
@@ -4,13 +4,18 @@ enablePlugins(SbtLicenseReport, JavaAppPackaging, WindowsPlugin)
 
 name := "rekordbox-repair"
 version := "0.3"
-scalaVersion := "2.12.8"
+scalaVersion := "2.13.8"
+scalacOptions ++= Seq(
+  "-deprecation",
+  "-feature",
+  "-unchecked",
+  "-Xfatal-warnings",
+)
 
-libraryDependencies += "org.scala-lang.modules" %% "scala-xml" % "1.1.1"
-libraryDependencies += "com.github.scopt" %% "scopt" % "3.7.1"
-libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.3"
-libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5" % Test
-
+libraryDependencies += "org.scala-lang.modules" %% "scala-xml" % "2.1.0"
+libraryDependencies += "com.github.scopt" %% "scopt" % "4.0.1"
+libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.11"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.11" % Test
 
 // Packaging config and mappings
 //
@@ -25,7 +30,7 @@ val osName = System.getProperty("os.name").toLowerCase
 val isMac = osName.startsWith("mac")
 val isWindows = osName.startsWith("win")
 
-mappings in Universal ++= {
+Universal / mappings ++= {
   val jreDir = if (isMac)
     Path("/Library/Java/JavaVirtualMachines/jdk1.8.0_211.jdk/Contents/Home/jre").asFile
   else if (isWindows)
@@ -41,7 +46,7 @@ mappings in Universal ++= {
   directory(jreDir)
 }
 
-mappings in Universal ++= {
+Universal / mappings ++= {
   val licenseReportsDir = target.value / "license-reports"
   streams.value.log.info(s"Adding license reports to package from $licenseReportsDir...")
   directory(licenseReportsDir)
@@ -54,11 +59,11 @@ val nonWindowsJavaHome = if (!isWindows)
 else
   Seq()
 
-javaOptions in Universal ++= nonWindowsJavaHome
+Universal / javaOptions ++= nonWindowsJavaHome
 
 
 // Windows packaging using WIX toolset
-name in Windows := s"rekordbox-repair-${version.value}" // Name of generated MSI file
+Windows / name := s"rekordbox-repair-${version.value}" // Name of generated MSI file
 wixProductLicense := Some(new sbt.File("LICENSE.rtf"))
 
 makeBatScripts := {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.2.8
+sbt.version = 1.6.2

--- a/src/main/scala/com/vividlab/rekordbox/FileUtils.scala
+++ b/src/main/scala/com/vividlab/rekordbox/FileUtils.scala
@@ -47,8 +47,8 @@ object FileUtils {
   def allSupportedFilesInDir(rootDir: File): Seq[File] = {
     def supported(filename: String): Boolean = supportedTypes.exists { st => filename.toLowerCase.endsWith(s".$st") }
 
-    def recursiveFilesInDir(dir: File): Array[File] = {
-      val files = dir.listFiles
+    def recursiveFilesInDir(dir: File): Seq[File] = {
+      val files = dir.listFiles.toIndexedSeq
       files.filter(f => supported(f.getName)) ++ files.filter(_.isDirectory).flatMap(recursiveFilesInDir)
     }
 

--- a/src/main/scala/com/vividlab/rekordbox/analyse/Analyser.scala
+++ b/src/main/scala/com/vividlab/rekordbox/analyse/Analyser.scala
@@ -7,7 +7,7 @@ import com.vividlab.rekordbox.{Config, FileUtils, OS}
 import com.vividlab.rekordbox.data.{CollectionTrack, CollectionTracks, RootPlaylist}
 import org.slf4j.LoggerFactory
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.xml.XML
 
 object Analyser {

--- a/src/main/scala/com/vividlab/rekordbox/analyse/LocateFileResult.scala
+++ b/src/main/scala/com/vividlab/rekordbox/analyse/LocateFileResult.scala
@@ -5,7 +5,6 @@ import java.io.File
 import com.vividlab.rekordbox.OS
 import com.vividlab.rekordbox.data.CollectionTrack
 
-import scala.collection.breakOut
 import scala.reflect.ClassTag
 
 sealed trait LocateFileResult {
@@ -40,9 +39,9 @@ case class MultipleLocations(track: CollectionTrack, newFiles: Seq[File]) extend
 
 case class LocateFileResults(results: Seq[LocateFileResult]) {
 
-  implicit class RichTraversable[A](collection: Traversable[A]) {
+  implicit class RichTraversable[A](collection: Iterable[A]) {
     def filterOnType[T <: A](implicit t: ClassTag[T]): Vector[T] = {
-      collection.filter(a => t.runtimeClass.isAssignableFrom(a.getClass)).map(_.asInstanceOf[T])(breakOut)
+      collection.toVector.collect { case a: T => a }
     }
   }
 

--- a/src/main/scala/com/vividlab/rekordbox/repair/RekordBoxRewriteRule.scala
+++ b/src/main/scala/com/vividlab/rekordbox/repair/RekordBoxRewriteRule.scala
@@ -4,7 +4,7 @@ import com.vividlab.rekordbox.analyse.{LocateFileResult, LocateFileResults, Relo
 import com.vividlab.rekordbox.data.Playlist
 import com.vividlab.rekordbox.{Config, FileUtils}
 
-import scala.language.implicitConversions
+import scala.language.{implicitConversions, reflectiveCalls}
 import scala.xml._
 import scala.xml.transform.RewriteRule
 
@@ -97,7 +97,7 @@ class RekordBoxRewriteRule(
     }
   }
 
-  private def rewriteAttribute(e: Elem, attributeName: String, newValue: String) = {
+  private def rewriteAttribute(e: Elem, attributeName: String, newValue: String): Elem = {
     e.copy(attributes = e.attributes.map {
       case attr@Attribute(attrName, _, _) if attrName == attributeName =>
         attr.pimpedCopy(value = newValue)

--- a/src/test/scala/com/vividlab/rekordbox/ConfigTest.scala
+++ b/src/test/scala/com/vividlab/rekordbox/ConfigTest.scala
@@ -1,10 +1,12 @@
 package com.vividlab.rekordbox
 
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
 import java.io.File
 
-import org.scalatest.{FreeSpec, Matchers}
 
-class ConfigTest extends FreeSpec with Matchers with TestData {
+class ConfigTest extends AnyFreeSpec with Matchers with TestData {
 
   "Valid arguments" in {
     val args: Array[String] = Array(

--- a/src/test/scala/com/vividlab/rekordbox/analyse/AnalyserTest.scala
+++ b/src/test/scala/com/vividlab/rekordbox/analyse/AnalyserTest.scala
@@ -1,12 +1,13 @@
 package com.vividlab.rekordbox.analyse
 
-import com.vividlab.rekordbox.{Config, FileUtils, OS, TestData, TestUtils}
-import org.scalatest.{FreeSpec, Matchers}
+import com.vividlab.rekordbox._
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 import org.slf4j.LoggerFactory
 
 import scala.io.Source
 
-class AnalyserTest extends FreeSpec with Matchers with TestData with TestUtils {
+class AnalyserTest extends AnyFreeSpec with Matchers with TestData with TestUtils {
   private val log = LoggerFactory.getLogger(getClass)
 
   "Analyse a broken rekordbox library" in {
@@ -44,8 +45,8 @@ class AnalyserTest extends FreeSpec with Matchers with TestData with TestUtils {
         val expectedReportSource = Source.fromFile(expectedReportFile)
         val actualReportSource = Source.fromFile(fixedLibraryReportFile)
 
-        val expectedReportText = expectedReportSource.getLines.mkString(OS.newLine)
-        val actualReportText = actualReportSource.getLines.mkString(OS.newLine)
+        val expectedReportText = expectedReportSource.getLines().mkString(OS.newLine)
+        val actualReportText = actualReportSource.getLines().mkString(OS.newLine)
 
         expectedReportSource.close()
         actualReportSource.close()

--- a/src/test/scala/com/vividlab/rekordbox/repair/RepairerTest.scala
+++ b/src/test/scala/com/vividlab/rekordbox/repair/RepairerTest.scala
@@ -2,11 +2,12 @@ package com.vividlab.rekordbox.repair
 
 import com.vividlab.rekordbox.analyse.Analyser
 import com.vividlab.rekordbox.{Config, TestData, TestUtils}
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.xml.XML
 
-class RepairerTest extends FreeSpec with Matchers with TestData with TestUtils {
+class RepairerTest extends AnyFreeSpec with Matchers with TestData with TestUtils {
 
   "Rewrite entire rekordbox XML file with repaired tracks" in {
     val config = Config(Array(


### PR DESCRIPTION
Nearly upgraded to OpenJDK 17 at the same time but decided to stay with Java 8 for now because the current OpenJDK builds (e.g. Zulu) are  intended for the more recent macOS versions Big Sur (11) and Monterey (12), however there may still be people running rekordbox on Catalina (10.15) or even earlier.