### PR TITLE
Fix file canonical path read errors

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import NativePackagerHelper._
 enablePlugins(SbtLicenseReport, JavaAppPackaging, WindowsPlugin)
 
 name := "rekordbox-repair"
-version := "0.4"
+version := "0.5"
 scalaVersion := "2.13.8"
 scalacOptions ++= Seq(
   "-deprecation",

--- a/src/main/scala/com/vividlab/rekordbox/FileUtils.scala
+++ b/src/main/scala/com/vividlab/rekordbox/FileUtils.scala
@@ -33,11 +33,33 @@ object FileUtils {
     *
     * @param location A location in rekordbox format extracted from XML
     */
-  def fileFromLocation(location: String): File =
-    new File(new URI(location
-      .replace("file://localhost/", "file:///")
-      .replace("#", "%23")
-    ))
+  def fileFromLocation(location: String): Option[File] = {
+    try {
+      Some(new File(new URI(location
+        .replace("file://localhost/", "file:///")
+        .replace("#", "%23")
+      )))
+    } catch {
+      case e: Throwable =>
+        // Swallow exceptions while trying to read them from the given location - urls with non-escaped characters have
+        // been experienced e.g. question marks, and we don't want one malformed url to cause the whole process to fail
+        log.error(s"Ignoring invalid file location $location, failed to read with error: ${e.getMessage}")
+        None
+    }
+  }
+
+  /**
+    * Safely retrieve the file system path for a given file, swallowing any exceptions and outputting them to the console
+    */
+  def fileCanonicalPath(file: File): Option[String] = {
+    try {
+      Some(file.getCanonicalPath)
+    } catch {
+      case e: Throwable =>
+        log.error(s"Ignoring file ${file.getName}, failed to read its path on the filesystem: ${e.getMessage}")
+        None
+    }
+  }
 
   /**
     * List all files in the given directory and all of its subdirectories.

--- a/src/main/scala/com/vividlab/rekordbox/analyse/Analyser.scala
+++ b/src/main/scala/com/vividlab/rekordbox/analyse/Analyser.scala
@@ -58,8 +58,8 @@ object Analyser {
   private def locateFile(track: CollectionTrack, files: Seq[File]): LocateFileResult = {
     val logPrefix = track.toString
 
-    track.file match {
-      case Some(file) =>
+    (track.file, track.filePath) match {
+      case (Some(file), Some(_)) =>
         if (file.exists()) {
           log.info(s"$logPrefix - OK")
           OK(track)
@@ -80,7 +80,7 @@ object Analyser {
             multiple
           }
         }
-      case None =>
+      case _ =>
         Invalid(track)
     }
   }

--- a/src/main/scala/com/vividlab/rekordbox/data/CollectionTrack.scala
+++ b/src/main/scala/com/vividlab/rekordbox/data/CollectionTrack.scala
@@ -19,16 +19,8 @@ case class CollectionTrack(
     s"$artistName - $albumName - '$name'"
   }
 
-  val file: Option[File] = try {
-    Some(FileUtils.fileFromLocation(location))
-  } catch {
-    case _: Throwable =>
-      // Swallow exceptions while trying to read them from the given location - urls with non-escaped characters have
-      // been experienced e.g. question marks, and we don't want one malformed url to cause the whole process to fail
-      None
-  }
-
-  val filePath: Option[String] = file.map(_.getCanonicalPath)
+  val file: Option[File] = FileUtils.fileFromLocation(location)
+  val filePath: Option[String] = file.flatMap(FileUtils.fileCanonicalPath)
 }
 
 object CollectionTrack {

--- a/src/test/resources/report-templates/expected-report-macos.txt
+++ b/src/test/resources/report-templates/expected-report-macos.txt
@@ -3,11 +3,11 @@ rekordbox Repair Report
 
 Summary
 
-Total tracks in collection: 8
+Total tracks in collection: 9
 Tracks OK: 2
 Tracks repaired: 3
 Tracks with multiple matches: 1
-Tracks with missing files: 1
+Tracks with missing files: 2
 Tracks with invalid paths: 1
 Tracks with path too long: 1
 Tracks on disk but not in rekordbox: 2
@@ -51,6 +51,9 @@ The files for the following tracks couldn't be found anywhere in the specified s
 
 No Artist - No Album - 'NOISE'
 Missing: {testLibraryDirectory}/PioneerDJ/Sampler/OSC_SAMPLER/PRESET ONESHOT/NOISE.wav
+
+No Artist - No Album - 'SoundCloud Plugin Track'
+Missing: /soundcloud:tracks:1149223021
 
 
 

--- a/src/test/resources/report-templates/expected-report-windows.txt
+++ b/src/test/resources/report-templates/expected-report-windows.txt
@@ -3,12 +3,12 @@ rekordbox Repair Report
 
 Summary
 
-Total tracks in collection: 8
+Total tracks in collection: 9
 Tracks OK: 2
 Tracks repaired: 3
 Tracks with multiple matches: 1
 Tracks with missing files: 1
-Tracks with invalid paths: 1
+Tracks with invalid paths: 2
 Tracks with path too long: 0
 Tracks on disk but not in rekordbox: 1
 
@@ -60,6 +60,9 @@ The following tracks couldn't be analysed or repaired because the file locations
 
 No Artist - No Album - 'Question Mark Track'
 Invalid: file://localhost/Name%20with%20?.mp3
+
+No Artist - No Album - 'SoundCloud Plugin Track'
+Invalid: file://localhost/soundcloud:tracks:1149223021
 
 
 

--- a/src/test/resources/xml-templates/broken-library.xml
+++ b/src/test/resources/xml-templates/broken-library.xml
@@ -64,6 +64,12 @@
                BitRate="2116" SampleRate="44100" Comments="" PlayCount="0" Rating="0"
                Location="file://localhost/Name%20with%20?.mp3"
                Remixer="" Tonality="" Label="" Mix=""/>
+        <TRACK TrackID="9" Name="SoundCloud Plugin Track" Artist="" Composer="" Album="" Grouping=""
+               Genre="" Kind="WAV File" Size="2345345" TotalTime="7" DiscNumber="0"
+               TrackNumber="0" Year="0" AverageBpm="0.00" DateAdded="2019-05-30"
+               BitRate="2116" SampleRate="44100" Comments="" PlayCount="0" Rating="0"
+               Location="file://localhost/soundcloud:tracks:1149223021"
+               Remixer="" Tonality="" Label="" Mix=""/>
     </COLLECTION>
     <PLAYLISTS>
         <NODE Type="0" Name="ROOT" Count="3">

--- a/src/test/resources/xml-templates/expected-fixed-library.xml
+++ b/src/test/resources/xml-templates/expected-fixed-library.xml
@@ -64,6 +64,12 @@
                BitRate="2116" SampleRate="44100" Comments="" PlayCount="0" Rating="0"
                Location="file://localhost/Name%20with%20?.mp3"
                Remixer="" Tonality="" Label="" Mix=""/>
+        <TRACK TrackID="9" Name="SoundCloud Plugin Track" Artist="" Composer="" Album="" Grouping=""
+               Genre="" Kind="WAV File" Size="2345345" TotalTime="7" DiscNumber="0"
+               TrackNumber="0" Year="0" AverageBpm="0.00" DateAdded="2019-05-30"
+               BitRate="2116" SampleRate="44100" Comments="" PlayCount="0" Rating="0"
+               Location="file://localhost/soundcloud:tracks:1149223021"
+               Remixer="" Tonality="" Label="" Mix=""/>
     </COLLECTION>
     <PLAYLISTS>
         <NODE Type="0" Name="ROOT" Count="3">

--- a/src/test/scala/com/vividlab/rekordbox/analyse/AnalyserTest.scala
+++ b/src/test/scala/com/vividlab/rekordbox/analyse/AnalyserTest.scala
@@ -25,12 +25,15 @@ class AnalyserTest extends AnyFreeSpec with Matchers with TestData with TestUtil
         lr.ok.size shouldBe 2
         lr.relocated.size shouldBe 3
         lr.multipleLocations.size shouldBe 1
-        lr.missing.size shouldBe 1
 
         if (OS.isMac) {
+          lr.missing.size shouldBe 2
+          lr.invalid.size shouldBe 1
           result.filesNotInRekordBox.size shouldBe 2
           result.filesWithPathTooLong.size shouldBe 1
         } else {
+          lr.missing.size shouldBe 1
+          lr.invalid.size shouldBe 2
           result.filesNotInRekordBox.size shouldBe 1
           result.filesWithPathTooLong.size shouldBe 0
         }


### PR DESCRIPTION
If the canonical path of a file fails to be read for any reason, the error will be reported to the console and the process will continue uninterrupted.